### PR TITLE
Implement BitmapResizeProcessor.

### DIFF
--- a/Texart.Tests/BitmapProcessors/BitmapResizeProcessorTests.cs
+++ b/Texart.Tests/BitmapProcessors/BitmapResizeProcessorTests.cs
@@ -1,0 +1,116 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using SkiaSharp;
+using Texart.BitmapProcessors;
+
+namespace Texart.Tests.BitmapProcessors
+{
+    [TestFixture]
+    public class BitmapResizeProcessorTests
+    {
+        [Test]
+        public async Task CanResizeWithSameAspectRatio()
+        {
+            using var sourceBitmap = CreateSourceBitmap(1000, 1000, 200, 200);
+            IBitmapProcessor<SKBitmap> resizeProcessor = new BitmapResizeProcessor(new SKSizeI(500, 500), SKFilterQuality.High);
+            var resizedList = await CollectAsync(resizeProcessor.Process(OneAsync(sourceBitmap)));
+            Assert.AreEqual(1, resizedList.Count);
+            var resizedBitmap = resizedList[0];
+            Assert.AreEqual(new SKSizeI(500, 500), new SKSizeI(resizedBitmap.Width, resizedBitmap.Height));
+
+            // top left
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(200, 199));
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(199, 200));
+            Assert.AreEqual(SKColors.Black, resizedBitmap.GetPixel(200, 200));
+
+            // top right
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(299, 199));
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(300, 200));
+            Assert.AreEqual(SKColors.Black, resizedBitmap.GetPixel(299, 200));
+
+            // bottom left
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(200, 300));
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(199, 299));
+            Assert.AreEqual(SKColors.Black, resizedBitmap.GetPixel(200, 299));
+
+            // bottom right
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(299, 300));
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(300, 299));
+            Assert.AreEqual(SKColors.Black, resizedBitmap.GetPixel(299, 299));
+        }
+
+        [Test]
+        public async Task CanResizeWithoutPreservingAspectRatio()
+        {
+            using var sourceBitmap = CreateSourceBitmap(1000, 1000, 200, 200);
+            IBitmapProcessor<SKBitmap> resizeProcessor = new BitmapResizeProcessor(new SKSizeI(500, 2000), SKFilterQuality.High);
+            var resizedList = await CollectAsync(resizeProcessor.Process(OneAsync(sourceBitmap)));
+            Assert.AreEqual(1, resizedList.Count);
+            var resizedBitmap = resizedList[0];
+            Assert.AreEqual(new SKSizeI(500, 2000), new SKSizeI(resizedBitmap.Width, resizedBitmap.Height));
+
+            // Some artifacts may be created when stretching. A tolerance lets us test that the resizing "somewhat" worked, since
+            // there are multiple ways to resize.
+            const int artifactTolerancePixels = 5;
+
+            // top left
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(200, 800 - artifactTolerancePixels));
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(199, 800 + artifactTolerancePixels));
+            Assert.AreEqual(SKColors.Black, resizedBitmap.GetPixel(200, 800 + artifactTolerancePixels));
+
+            // top right
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(299, 800 - artifactTolerancePixels));
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(300, 800 + artifactTolerancePixels));
+            Assert.AreEqual(SKColors.Black, resizedBitmap.GetPixel(299, 800 + artifactTolerancePixels));
+
+            // bottom left
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(200, 1199 + artifactTolerancePixels));
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(199, 1199 - artifactTolerancePixels));
+            Assert.AreEqual(SKColors.Black, resizedBitmap.GetPixel(200, 1199 - artifactTolerancePixels));
+
+            // bottom right
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(299, 1199 + artifactTolerancePixels));
+            Assert.AreEqual(SKColors.White, resizedBitmap.GetPixel(300, 1199 - artifactTolerancePixels));
+            Assert.AreEqual(SKColors.Black, resizedBitmap.GetPixel(299, 1199 - artifactTolerancePixels));
+        }
+
+        // black rectangle in the middle of a white background
+        private static SKBitmap CreateSourceBitmap(int width, int height, float rectWidth, float rectHeight)
+        {
+            Debug.Assert(rectWidth <= width);
+            Debug.Assert(rectHeight <= height);
+            using var paint = new SKPaint
+            {
+                Color = SKColors.Black
+            };
+            var bitmap = new SKBitmap(
+                width, width,
+                SKImageInfo.PlatformColorType, SKAlphaType.Opaque
+            );
+            using var canvas = new SKCanvas(bitmap);
+            canvas.Clear(SKColors.White);
+            canvas.DrawRect(
+                (width - rectWidth) / 2f, (height - rectHeight) / 2f,
+                rectWidth, rectHeight,
+                paint);
+            return bitmap;
+        }
+
+        private static async IAsyncEnumerable<T> OneAsync<T>(T value)
+        {
+            yield return await Task.Run(() => value);
+        }
+
+        private static async Task<List<T>> CollectAsync<T>(IAsyncEnumerable<T> asyncEnumerable)
+        {
+            var collector = new List<T>();
+            await foreach (var item in asyncEnumerable)
+            {
+                collector.Add(item);
+            }
+            return collector;
+        }
+    }
+}

--- a/Texart.Tests/Texart.Tests.csproj
+++ b/Texart.Tests/Texart.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <LangVersion>8</LangVersion>
+    <NullableContextOptions>disable</NullableContextOptions>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Texart\Texart.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Texart.sln
+++ b/Texart.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Texart.Builtin", "Texart.Bu
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Texart.Api", "Texart.Api\Texart.Api.csproj", "{E558BD10-8E2C-4EBC-812F-6559CBC7F8FD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Texart.Tests", "Texart.Tests\Texart.Tests.csproj", "{7FACF95A-A15D-4C77-9FF9-1325351E08CD}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Texart.Plugins.Tests", "Texart.Plugins.Tests\Texart.Plugins.Tests.csproj", "{837F51C6-C11B-4A0E-8A34-CADC0C2D15B7}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Texart.Api.Tests", "Texart.Api.Tests\Texart.Api.Tests.csproj", "{FBA96944-9DB2-4667-8AB6-9FDEEFEA8A40}"
@@ -53,6 +55,10 @@ Global
 		{FBA96944-9DB2-4667-8AB6-9FDEEFEA8A40}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FBA96944-9DB2-4667-8AB6-9FDEEFEA8A40}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FBA96944-9DB2-4667-8AB6-9FDEEFEA8A40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7FACF95A-A15D-4C77-9FF9-1325351E08CD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FACF95A-A15D-4C77-9FF9-1325351E08CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FACF95A-A15D-4C77-9FF9-1325351E08CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7FACF95A-A15D-4C77-9FF9-1325351E08CD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Texart.sln.DotSettings
+++ b/Texart.sln.DotSettings
@@ -8,6 +8,8 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Garamond/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=monospace/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Renderers/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Resizer/@EntryIndexedValue">True</s:Boolean>
+	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Skia/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Texart/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Unices/@EntryIndexedValue">True</s:Boolean>

--- a/Texart/BitmapProcessors/BitmapResizeProcessor.cs
+++ b/Texart/BitmapProcessors/BitmapResizeProcessor.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using SkiaSharp;
+
+namespace Texart.BitmapProcessors
+{
+    /// <summary>
+    /// An <see cref="IBitmapProcessor{T}"/> that resizes a given bitmap.
+    /// </summary>
+    public sealed class BitmapResizeProcessor : IBitmapProcessor<SKBitmap>
+    {
+        /// <summary>
+        /// The size of the processed (output) bitmap. 
+        /// </summary>
+        public SKSizeI TargetSize { get; }
+
+        /// <summary>
+        /// The resize filter quality.
+        /// </summary>
+        public SKFilterQuality FilterQuality { get; }
+
+        /// <summary>
+        /// Creates a <see cref="BitmapResizeProcessor"/> with the provided target size.
+        /// </summary>
+        /// <param name="targetSize">The size of the processed (output) bitmap.</param>
+        /// <param name="filterQuality">The resize filter quality.</param>
+        /// <exception cref="ArgumentException">
+        ///     If <c>targetSize.Width</c> or <c>targetSize.Height</c> are negative.
+        /// </exception>
+        public BitmapResizeProcessor(SKSizeI targetSize, SKFilterQuality filterQuality)
+        {
+            if (targetSize.Width < 0)
+            {
+                throw new ArgumentException($"{nameof(targetSize.Width)} must be non-negative.");
+            }
+            if (targetSize.Height < 0)
+            {
+                throw new ArgumentException($"{nameof(targetSize.Height)} must be non-negative.");
+            }
+            TargetSize = targetSize;
+            FilterQuality = filterQuality;
+        }
+
+        /// <inheritdoc cref="IBitmapProcessor{T}.Process"/>
+        public async IAsyncEnumerable<SKBitmap> Process(IAsyncEnumerable<SKBitmap> bitmaps)
+        {
+            await foreach (var bitmap in bitmaps)
+            {
+                var resizedImageInfo = bitmap.Info.WithSize(TargetSize.Width, TargetSize.Height);
+                yield return bitmap.Resize(resizedImageInfo, FilterQuality);
+            }
+        }
+    }
+}

--- a/Texart/IBitmapProcessor.cs
+++ b/Texart/IBitmapProcessor.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using SkiaSharp;
+
+namespace Texart
+{
+    /// <summary>
+    /// An <see cref="IBitmapProcessor{T}"/> processes <see cref="SKBitmap"/> into an output of type <typeparamref name="T"/>.
+    /// A processor implementation should be able to handle an async stream of <see cref="SKBitmap"/>.
+    /// </summary>
+    /// <typeparam name="T">The processed (output) type.</typeparam>
+    public interface IBitmapProcessor<out T>
+    {
+        /// <summary>
+        /// Processes a stream of incoming <see cref="SKBitmap"/> to produce a stream of <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="bitmaps">The bitmaps to process.</param>
+        /// <returns>Async stream of processed <typeparamref name="T"/>.</returns>
+        IAsyncEnumerable<T> Process(IAsyncEnumerable<SKBitmap> bitmaps);
+    }
+}


### PR DESCRIPTION
This allows resizing images early in the Texart pipeline. I'm placing this outside Texart.Api since this is transparent to plugins. A reasonable way to use this might be a command line argument, such as `--pre-resize 1000x1000`.